### PR TITLE
Fix ambiguous SortDescriptor

### DIFF
--- a/Sources/RealmStorage/Persistence/RealmPersistence+Extensions.swift
+++ b/Sources/RealmStorage/Persistence/RealmPersistence+Extensions.swift
@@ -16,7 +16,7 @@ public protocol DatabaseSortableCollection: RandomAccessCollection where Self.El
     // MARK: Appearance
     
     func sorted(
-        by sortDescriptors: [SortDescriptor]
+        by sortDescriptors: [RealmSwift.SortDescriptor]
     ) -> Results<Element>
     
     func sorted<S: Sequence>(
@@ -32,7 +32,7 @@ public extension DatabaseSortableCollection where Element: StorageObject {
     func sorted<S: Sequence>(
         by sortDescriptors: S
     ) -> Results<Element> where S.Iterator.Element == DatabaseSortDescriptor {
-        let sortDescriptors = sortDescriptors.compactMap { $0 as? SortDescriptor }
+        let sortDescriptors = sortDescriptors.compactMap { $0 as? RealmSwift.SortDescriptor }
         
         return self.sorted(by: sortDescriptors)
     }

--- a/Sources/RealmStorage/PredicateFlow/Realm/Classes/LinkingObj+PF.swift
+++ b/Sources/RealmStorage/PredicateFlow/Realm/Classes/LinkingObj+PF.swift
@@ -17,7 +17,7 @@ extension LinkingObjects {
         return filter(predicateResult.query())
     }
 
-    public func sorted(_ sortDescriptions: SortDescriptor...) -> Results<Element> {
+    public func sorted(_ sortDescriptions: RealmSwift.SortDescriptor...) -> Results<Element> {
         return sorted(by: sortDescriptions)
     }
 

--- a/Sources/RealmStorage/PredicateFlow/Realm/Classes/List+PF.swift
+++ b/Sources/RealmStorage/PredicateFlow/Realm/Classes/List+PF.swift
@@ -13,7 +13,7 @@ extension List {
         return filter(predicateResult.query())
     }
 
-    public func sorted(_ sortDescriptions: SortDescriptor...) -> Results<Element> {
+    public func sorted(_ sortDescriptions: RealmSwift.SortDescriptor...) -> Results<Element> {
         return sorted(by: sortDescriptions)
     }
 

--- a/Sources/RealmStorage/PredicateFlow/Realm/Classes/Results+PF.swift
+++ b/Sources/RealmStorage/PredicateFlow/Realm/Classes/Results+PF.swift
@@ -13,7 +13,7 @@ extension Results {
         return filter(predicateResult.query())
     }
 
-    public func sorted(_ sortDescriptions: SortDescriptor...) -> Results<Element> {
+    public func sorted(_ sortDescriptions: RealmSwift.SortDescriptor...) -> Results<Element> {
         return sorted(by: sortDescriptions)
     }
 

--- a/Sources/RealmStorage/PredicateFlow/Realm/Classes/SortDescriptor+PF.swift
+++ b/Sources/RealmStorage/PredicateFlow/Realm/Classes/SortDescriptor+PF.swift
@@ -7,7 +7,7 @@
 
 import RealmSwift
 
-extension SortDescriptor {
+extension RealmSwift.SortDescriptor {
 
     public init(_ predicateField: PredicateField, ascending: Bool = true) {
         self.init(keyPath: predicateField.keyPath(), ascending: ascending)
@@ -16,11 +16,11 @@ extension SortDescriptor {
 
 extension PredicateField {
 
-    public func ascending() -> SortDescriptor {
+    public func ascending() -> RealmSwift.SortDescriptor {
         return SortDescriptor(self, ascending: true)
     }
 
-    public func descending() -> SortDescriptor {
+    public func descending() -> RealmSwift.SortDescriptor {
         return SortDescriptor(self, ascending: false)
     }
 }


### PR DESCRIPTION
Recently RealmStorage becomes fail compilation with `ambiguous SortDescriptor` error. The PR fix this error.